### PR TITLE
[COM-251] Test against pathname, not including any querystring parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-middleware-registry",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-middleware-registry",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "A middleware registry for NextJS.",
   "main": "dist/index.js",
   "types": "dist/types",

--- a/src/MiddlewareRegistry.ts
+++ b/src/MiddlewareRegistry.ts
@@ -78,7 +78,7 @@ export class MiddlewareRegistry<R extends MiddlewareRequest> {
         if (MiddlewareRegistry.isNextRequest(this.request)){
             return this.request.nextUrl.pathname;
         } 
-        return new URL(this.request.url).pathname;
+        return this.request.url.split('?')[0];
     
     }
 

--- a/src/MiddlewareRegistry.ts
+++ b/src/MiddlewareRegistry.ts
@@ -3,7 +3,6 @@ import { NextRequest } from "next/server";
 import { MiddlewareExitCode } from "./MiddlewareExitCode";
 import { MiddlewareConfig } from "./MiddlewareConfig";
 import { MiddlewareFunction } from "./MiddlewareFunction";
-import { NextApiRequest } from "next";
 import { MiddlewareRequest } from "./MiddlewareRequest";
 
 export class MiddlewareRegistry<R extends MiddlewareRequest> {
@@ -79,7 +78,7 @@ export class MiddlewareRegistry<R extends MiddlewareRequest> {
         if (MiddlewareRegistry.isNextRequest(this.request)){
             return this.request.nextUrl.pathname;
         } 
-        return (this.request as NextApiRequest).url;
+        return new URL(this.request.url).pathname;
     
     }
 

--- a/src/tests/queryString.spec.ts
+++ b/src/tests/queryString.spec.ts
@@ -1,0 +1,18 @@
+import { NextApiRequest } from "next";
+import { MiddlewareRegistry } from "../MiddlewareRegistry";
+
+describe('query strings', () => {
+    it('should not include query strings when matching a request', async () => {
+        // GIVEN a request to a path /a with middleware A, which includes a query string
+        const request = { url: '/api/a?test=123' } as NextApiRequest;
+        const registry = new MiddlewareRegistry(request);
+        const middlewareA = jest.fn();
+        registry.add('/api/a', middlewareA);
+
+        // WHEN executed
+        await registry.execute();
+
+        // EXPECT middleware to run regardless of query string
+        expect(middlewareA).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
When testing against `req.url`, this inadvertently included querystring parameters. Solution is to strip off query