### PR TITLE
COM-275 Updates the registry to handle middleware arrays.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,7 +8,7 @@ const baseConfig = {
 }
 
 const unitConfig = {
-  testRegex: ['/*.u.spec.*$'],
+  testRegex: ['/*.spec.*$'],
   ...baseConfig,
 }
 

--- a/src/MiddlewareExitCode.ts
+++ b/src/MiddlewareExitCode.ts
@@ -1,6 +1,8 @@
 export const MiddlewareExitCode = {
-  NEXT: 'NEXT',
-  EXIT: 'EXIT',
+  NEXT_IN_ARRAY: 'NEXT_IN_ARRAY',
+  NEXT_IN_CHAIN: 'NEXT_IN_CHAIN',
+  EXIT_ARRAY: 'EXIT_ARRAY',
+  EXIT_CHAIN: 'EXIT_CHAIN',
 } as const
 
 export type MiddlewareExitCode = typeof MiddlewareExitCode[keyof typeof MiddlewareExitCode]

--- a/src/MiddlewareRegistry.ts
+++ b/src/MiddlewareRegistry.ts
@@ -43,11 +43,13 @@ export class MiddlewareRegistry<R extends MiddlewareRequest> {
     let middlewareExitCode: MiddlewareExitCode = MiddlewareExitCode.NEXT_IN_CHAIN
     let middlewareFunction = middlewareChain.next()
     do {
-      if (Array.isArray(middlewareFunction?.value)) {
-        middlewareExitCode = await this.executeMiddlewareArray(middlewareFunction.value) || MiddlewareExitCode.NEXT_IN_CHAIN
+      if (Array.isArray(middlewareFunction.value)) {
+        middlewareExitCode =
+          (await this.executeMiddlewareArray(middlewareFunction.value)) || MiddlewareExitCode.NEXT_IN_CHAIN
         middlewareFunction = middlewareChain.next()
       } else {
-        middlewareExitCode = await (middlewareFunction.value as MiddlewareFunction)(this.request) || MiddlewareExitCode.NEXT_IN_CHAIN
+        middlewareExitCode =
+          (await (middlewareFunction.value as MiddlewareFunction)(this.request)) || MiddlewareExitCode.NEXT_IN_CHAIN
         middlewareFunction = middlewareChain.next()
       }
     } while (middlewareExitCode !== MiddlewareExitCode.EXIT_CHAIN)
@@ -63,7 +65,7 @@ export class MiddlewareRegistry<R extends MiddlewareRequest> {
     let middlewareExitCode: MiddlewareExitCode = MiddlewareExitCode.NEXT_IN_ARRAY
     let middlewareFunction = middlewareArrayGenerator.next()
     do {
-      middlewareExitCode = await middlewareFunction.value(this.request) || MiddlewareExitCode.NEXT_IN_ARRAY
+      middlewareExitCode = (await middlewareFunction.value(this.request)) || MiddlewareExitCode.NEXT_IN_ARRAY
       middlewareFunction = middlewareArrayGenerator.next()
     } while (middlewareExitCode === MiddlewareExitCode.NEXT_IN_ARRAY)
     return middlewareExitCode
@@ -74,7 +76,11 @@ export class MiddlewareRegistry<R extends MiddlewareRequest> {
    * route configurations to run middleware against.
    * @private
    */
-  private *composeMiddlewareChain(): Generator<MiddlewareFunction | MiddlewareFunction[], MiddlewareFunction, undefined> {
+  private *composeMiddlewareChain(): Generator<
+    MiddlewareFunction | MiddlewareFunction[],
+    MiddlewareFunction,
+    undefined
+  > {
     for (const [serializedKey, config] of this.registry) {
       const route = this.deserializeKeyToPath(serializedKey)
       if (
@@ -89,7 +95,9 @@ export class MiddlewareRegistry<R extends MiddlewareRequest> {
     return async () => MiddlewareExitCode.EXIT_CHAIN
   }
 
-  private *composeMiddlewareArray(middlewareFunctionArray: MiddlewareFunction[]): Generator<MiddlewareFunction, MiddlewareFunction, undefined> {
+  private *composeMiddlewareArray(
+    middlewareFunctionArray: MiddlewareFunction[]
+  ): Generator<MiddlewareFunction, MiddlewareFunction, undefined> {
     for (const middlewareFunction of middlewareFunctionArray) {
       yield middlewareFunction
     }

--- a/src/tests/execute.spec.ts
+++ b/src/tests/execute.spec.ts
@@ -1,5 +1,6 @@
 import { MiddlewareRegistry } from '../MiddlewareRegistry'
 import { NextApiRequest } from 'next'
+import { MiddlewareExitCode } from "../MiddlewareExitCode";
 
 describe('MiddlewareRegistry.execute', () => {
   it('should not call a middleware before execute', async () => {
@@ -17,5 +18,42 @@ describe('MiddlewareRegistry.execute', () => {
 
     // EXPECT the middleware to have been called
     expect(middleware).toHaveBeenCalledTimes(2)
+  })
+
+  it('should run all middlewares in the middleware array when none have an exit code', async () => {
+    const middleware1 = jest.fn()
+    const middleware2 = jest.fn()
+    const middleware3 = jest.fn()
+
+    const req = { url: '/api/a/b/c' } as NextApiRequest
+    const registry = new MiddlewareRegistry(req)
+
+    registry.add('/api/(.*)', [middleware1, middleware2, middleware3])
+    await registry.execute()
+
+    expect(middleware1).toHaveBeenCalledTimes(1)
+    expect(middleware2).toHaveBeenCalledTimes(1)
+    expect(middleware3).toHaveBeenCalledTimes(1)
+  })
+
+  // eslint-disable-next-line max-len
+  it('should run all middlewares up until one returns the EXIT_ARRAY exit code and should continue to the next middleware in the chain.', async () => {
+    const middleware1 = jest.fn()
+    const middleware2 = jest.fn().mockReturnValue(Promise.resolve(MiddlewareExitCode.EXIT_ARRAY))
+    const middleware3 = jest.fn()
+    const middleware4 = jest.fn()
+
+    const req = { url: '/api/a/b/c' } as NextApiRequest
+    const registry = new MiddlewareRegistry(req)
+
+    registry.add('/api/(.*)', [middleware1, middleware2, middleware3], { transparent: true })
+    registry.add('/api/a/b/c', middleware4)
+
+    await registry.execute()
+
+    expect(middleware1).toHaveBeenCalledTimes(1)
+    expect(middleware2).toHaveBeenCalledTimes(1)
+    expect(middleware3).not.toHaveBeenCalled()
+    expect(middleware4).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
This allows a middleware configuration to have an array that evaluates as an individual generator, allowing the registry to traverse the array and exit at any time based on the return MiddlewareExitCode.